### PR TITLE
Update to Fastlane 2.51.0

### DIFF
--- a/ExampleFastfile
+++ b/ExampleFastfile
@@ -1,4 +1,4 @@
-fastlane_version "1.55.0"
+fastlane_version "2.51.0"
 default_platform :ios
 import_from_git(url:"git@github.com:Raizlabs/fastlane-shared.git", path:"SharedFastfile.rb")
 

--- a/ExampleFastfile
+++ b/ExampleFastfile
@@ -6,6 +6,8 @@ platform :ios do
 
   before_all do
     ENV['RZ_APP_NAME'] = 'MyApp'
+    
+    super_before
   end
 
   desc "Develop"

--- a/ExampleFastfile
+++ b/ExampleFastfile
@@ -23,7 +23,7 @@ platform :ios do
   end
 
   desc "App Store"
-  lane :appstore do
+  lane :production do
     build("#{app_name}-AppStore", 'app-store')
     run_tests
   end

--- a/SharedFastfile.rb
+++ b/SharedFastfile.rb
@@ -53,8 +53,8 @@ platform :ios do
 
   # Helpers
 
-  def build(scheme, export_method, use_legacy_build = true)
-    puts "Building scheme #{scheme} legacy: #{use_legacy_build} export: #{export_method}"
+  def build(scheme, export_method)
+    puts "Building scheme #{scheme} export: #{export_method}"
 
     set_build_number
     gym(
@@ -65,7 +65,6 @@ platform :ios do
       scheme: scheme,
       workspace: workspace_name,
       xcargs: "BUILD_NUMBER=#{build_number}",
-      use_legacy_build_api: use_legacy_build,
       export_method: export_method
     )
   end


### PR DESCRIPTION
fastlane removed the `use_legacy_build_api` argument from `gym` at the end of 2016 and now it causes an error that prevents the tool from running. So I deleted it. That build argument was used to make Xcode 6 and 7 compatible, but that's not really an issue for us anymore.

Also, I noticed a warning when using the ExampleFastFile. Fastlane has added a new action called "appstore" and that conflicts with the lane of the same name, so I had to rename the lane :(

There's one big caveat about this PR though. If anyone is using the SharedFastFile AND they are providing a `false` value to `use_legacy_build_api`, this change will cause their build to fail. I don't think that should be an issue because, like I said that argument is used for Xcode 7 (and everyone should be on Xcode 8 by now), but I wanted to bring this up in case this breaks someone's build.